### PR TITLE
v0.0.1e2 — Oakland

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,4 +1,4 @@
-# Doxyfile 1.9.8
+ 1.9.8
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -48,7 +48,7 @@ PROJECT_NAME           = "NeBoot"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.0.1dev
+PROJECT_NUMBER         = dev
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/tex/pci-tree.tex
+++ b/docs/tex/pci-tree.tex
@@ -67,8 +67,8 @@ Below are the official implementations of the PCI-Tree, organized by their progr
 
 \subsection{Forth}
 
-\begin{ImplCxx}
+\begin{ImplForth}
 \item {No Implementation yet}
-\end{ImplCxx}
+\end{ImplForth}
 
 \end{document}

--- a/docs/tex/pci-tree.tex
+++ b/docs/tex/pci-tree.tex
@@ -1,0 +1,74 @@
+\documentclass{article}
+\usepackage{graphicx} % Required for inserting images
+
+\title{The PCI Tree System}
+\author{Amlal El Mahrouss}
+\date{\today}
+
+\usepackage{listings}
+
+\lstset { %
+    language=C++,
+}
+
+\begin{document}
+
+\maketitle
+
+\section{Abstract}
+
+The PCI tree is an architecture designed to abstract away device specific data. One leaf might for instance hold an AHCI's HBA (Host Bus Adapter) into a '/pci-tree/@ahci' for instance. The advantage of this approach is the ability to quickly lookup and recognize a device from a tree given by a firmware at handoff.
+
+\section{The Protocol}
+
+Each leaf has a identification number of '0xfeedd00d', then followed by the version in a binary encoded format (0x1000). The offset and size of the offset and then given by the firmware. A PCI-Tree is assembled by the firmware itself. As the structures are not packed, thus multi-platform portability isn't possible.
+
+\section{Trade-offs}
+
+The trade-offs (portability, complexity) are largely justified by the need of a better and more straightforward way to recognize devices at the firmware level, the PCI tree approach helps us do exactly that.
+
+\subsection{Implementation of a PCI-Tree Leaf}
+
+Language of implementation is the C programming language
+
+\begin{lstlisting}
+struct hw_cb_pci_tree {
+  cb_pci_num_t d_magic;
+  cb_pci_num_t d_version;
+  cb_pci_num_t d_off_props;
+  cb_pci_num_t d_off_struct;
+  cb_pci_num_t d_sz_props;
+  cb_pci_num_t d_sz_struct;
+
+  cb_pci_num_t d_first_node;
+  cb_pci_num_t d_next_sibling;
+
+  cb_pci_char_t d_name[NB_PCI_NAME_LEN];
+};
+
+\end{lstlisting}
+
+\section{Official Implementations}
+
+Below are the official implementations of the PCI-Tree, organized by their programming languages.
+
+\subsection{ISO C}
+
+\begin{ImplC}
+\item {SNU Trusted Base:} https://snu.systems
+\item {NeBoot (NeKernel Boot):} https://github.com/nekernel-org/neboot
+\end{ImplC}
+
+\subsection{ISO C++}
+
+\begin{ImplCxx}
+\item {No Implementation yet}
+\end{ImplCxx}
+
+\subsection{Forth}
+
+\begin{ImplCxx}
+\item {No Implementation yet}
+\end{ImplCxx}
+
+\end{document}

--- a/mmap/generic-epm.json
+++ b/mmap/generic-epm.json
@@ -1,9 +1,11 @@
 {
-  "machine": "EPM GENERIC",
-  "type": "Generic",
-  "vendor": "NeKernel.org",
-  "fb": "0x1000000",
-  "boot": "0x4000000",
-  "pci-tree": "0x8002000",
-  "eeprom": "0x0000000"
+    "__pci-tree-meta": true,
+    "__pci-tree-version": 1,
+    "machine": "EPM GENERIC",
+    "type": "Generic",
+    "vendor": "NeKernel.org",
+    "fb": "0x1000000",
+    "boot": "0x4000000",
+    "pci-tree": "0x8002000",
+    "eeprom": "0x0000000"
 }


### PR DESCRIPTION
# v0.0.1e2 — Oakland

## Brief

This release provides fixes and improvements to the PCI-Tree.

## Release Notes

- PCI-Tree draft
- Documentation fixes
- Device Information Format (JSON based)
